### PR TITLE
Unordered list tags are passed similarly to ordered list tags

### DIFF
--- a/WA-Parser.py
+++ b/WA-Parser.py
@@ -93,6 +93,7 @@ def format_content(content):
 
         # List Items
         text = re.sub(r'\[ol\]|\[/ol\]', r'', text)
+        text = re.sub(r'\[ul\]|\[/ul\]', r'', text)
         text = re.sub(r'\[li\](.*?)\[/li\]', r'- \1', text)
 
     return text


### PR DESCRIPTION
This fixes the issue I raised in #6 by handling `[ul]` tags the same way we handle `[ol]` tags. 